### PR TITLE
use tiff2pdf instead of converting first to ps and then to pdf

### DIFF
--- a/docs/manual-de.docbook
+++ b/docs/manual-de.docbook
@@ -248,20 +248,12 @@
 						</listitem>
 					</varlistentry>
 					<varlistentry>
-						<term>tiff2ps</term>
-						<listitem><para>Ein kleines Utility, um TIFF-Dateien ins Postscript-Format zu
+						<term>tiff2pdf</term>
+						<listitem><para>Ein kleines Utility, um TIFF-Dateien verlustfrei ins PDF-Format zu
                             konvertieren. Es wird von den Standard-Skripten benötigt, um Faxe in PDF-Dateien
-							umzuwandeln (SFF->TIFF->PS->PDF :-} ). Es ist oft in einem Paket namens 
+							umzuwandeln (SFF->TIFF->PDF :-} ). Es ist oft in einem Paket namens 
                             <literal>tiff</literal> oder <literal>tifftools</literal> enthalten. 
                             Details unter <ulink url="http://www.libtiff.org"/>
-						</para></listitem>
-					</varlistentry>
-					<varlistentry>
-						<term>ps2pdf</term>
-						<listitem><para>Noch ein kleines Utility für die Kette SFF->PDF - diesmal für
-							die Konvertierung von Adobe PostScript in Adobe PDF. Es ist bei Ghostscript
-                            dabei, sodass Sie es höchst wahrscheinlich bereits haben.
-                            (<ulink url="http://www.gnu.org/software/ghostscript/ghostscript.html"/>)
 						</para></listitem>
 					</varlistentry>
 					<varlistentry>
@@ -1976,7 +1968,7 @@ is not present, current time as returned by localtime() is used.
 				<screen><command>sfftobmp -tif myfile.sff outfile.tiff</command></screen>
 
 				<para>Sie erhalten eine TIFF-Datei, die Sie mit den TIFF-Tools (z.B.
-                <command>tiff2ps</command>) in nahezu jedes andere nützliche Format
+                <command>tiff2pdf</command>) in nahezu jedes andere nützliche Format
 				konvertieren können.
 				</para>
 			</sect3>

--- a/docs/manual.docbook
+++ b/docs/manual.docbook
@@ -224,18 +224,11 @@
 						</listitem>
 					</varlistentry>
 					<varlistentry>
-						<term>tiff2ps</term>
-						<listitem><para>A small utility to convert TIFF files to the Postscript format. It's needed by
-							the default script to convert faxes to PDF files (SFF->TIFF->PS->PDF :-} ).
+						<term>tiff2pdf</term>
+						<listitem><para>A small utility to losslessly convert TIFF files to the PDF format. It's needed by
+							the default script to convert faxes to PDF files (SFF->TIFF->PDF :-} ).
 							It's often included in a package called <literal>tiff</literal> or
 							<literal>tifftools</literal>. Details on <ulink url="http://www.libtiff.org"/>
-						</para></listitem>
-					</varlistentry>
-					<varlistentry>
-						<term>ps2pdf</term>
-						<listitem><para>Again a small utility for the SFF->PDF chain - this time for the
-							conversion of Adobe PostScript to Adobe PDF. It's part of Ghostscript, so
-							you most likely have it already. (<ulink url="http://www.gnu.org/software/ghostscript/ghostscript.html"/>)
 						</para></listitem>
 					</varlistentry>
 					<varlistentry>
@@ -1788,7 +1781,7 @@ is not present, current time as returned by localtime() is used.
 				<screen><command>sfftobmp -tif myfile.sff outfile.tiff</command></screen>
 
 				<para>This will give you a TIFF file which you can convert now to nearly
-				any other useful format with the TIFF tools, for example <command>tiff2ps</command>.
+				any other useful format with the TIFF tools, for example <command>tiff2pdf</command>.
 				</para>
 			</sect3>
 			<sect3 id="cff"><title>Color faxes - the CFF format</title>

--- a/scripts/helpers.pyin
+++ b/scripts/helpers.pyin
@@ -23,7 +23,7 @@ if sfftobmp_major_version <= 2:
         __call('sff to tif', "sfftobmp", "-tif", infile, outfile)
 else:
     def sff2tif(infile, outfile):
-        __call('sff to tif', "sfftobmp", "-tif", infile, "-o", outfile)
+        __call('sff to tif', "sfftobmp", "-q", "-t4", infile, "-o", outfile)
 
 # Note: readConfig is now imported from capisuite.config
 
@@ -129,13 +129,13 @@ def sendMIMEMail(mail_from, mail_to, mail_subject, mail_type,
             # convert sff -> tif
             sff2tif(attachment, "%s.tif" % basepath)
             # convert tif -> ps -> pdf
-            cmd = "tiff2ps -h11 -H12 -L.5 -w8.5 -a %s | ps2pdf -sPAPERSIZE=a4 - -" % escape("%s.tif" %basepath)
+            cmd = "tiff2pdf %s" % escape("%s.tif" %basepath)
             try:
                 status, content = commands.getstatusoutput(cmd)
             finally:
                 os.unlink("%s.tif" % basepath)
             if status:
-                raise ConvertionError("Error while calling tiff2ps or ps2pdf. "
+                raise ConvertionError("Error while calling tiff2pdf. "
                                       "Not installed?")
             filepart = email.MIMEBase.MIMEBase("application","pdf",
                                                name = "%s.pdf" % basename)


### PR DESCRIPTION
this is not only a lot faster, but also allows lossless conversion.
Along that line, don't try to alter the pagesize during conversion to
PDF. PDF-viewer applications do a great job adjusting to the paper-size
as the user wants it, so let the user make the decision. After all when
having the PDF, it is unlikely that it will be printed out anyway.
