### PR TITLE
don't return empty user-values, but return default instead

### DIFF
--- a/src/capisuite-py/config.py.in
+++ b/src/capisuite-py/config.py.in
@@ -93,13 +93,15 @@ class CSConfigParser(ConfigParser):
         Returns the value for this option or None if it's not found
         """
         if self.has_option(user, option):
-            return self.get(user, option)
+            retval = self.get(user, option)
         elif self.has_option('GLOBAL', option):
-            return self.get('GLOBAL', option)
+            retval = self.get('GLOBAL', option)
         elif fail:
             raise NoOptionError(user, option)
-        else:
-            return default
+        # don't return empty values
+        if retval:
+            return retval
+        return default
 
     def listUsers(self):
         ul = [ u


### PR DESCRIPTION
since otherwise it contradicts the documentation when e.g. sending mail
notifications, as the code that requests e.g. the fax.email property
provides the user as default.
But when using the empty string as documented to use the user's name as
sender, it returns the empty string and that then causes sending the
mail to fail, as there is no recipient.
